### PR TITLE
VDEF doesn't show up in the legend

### DIFF
--- a/js/RrdGraph.js
+++ b/js/RrdGraph.js
@@ -323,7 +323,7 @@ RrdGraphDesc.prototype.gprint = function (graph, vname, cf, format, strftimefmt)
 	this.vname = vname;
 	this.vidx = graph.find_var(vname);
 	this.legend = '';
-	if (format === undefined) {
+	if (!format) {
 		this.format = cf;
 		switch (graph.gdes[this.vidx].gf) {
 			case RrdGraphDesc.GF_DEF:


### PR DESCRIPTION
The GPRINT of a VDEF doesn't have a CF. For example:

> "GPRINT:avg:LAST:%5.1lf%s Last"
> "GPRINT:tot:%5.1lf%s Total\l"

The format will be passed via the cf variable, so format is not defined. But it
didn't show up in the legend. Firebug showed variable format isn't undefined,
but an empty string in case of VDEF. So just check for falsy.
