### PR TITLE
Don't show legend for HRULEs with empty description text

### DIFF
--- a/js/RrdGraph.js
+++ b/js/RrdGraph.js
@@ -1692,6 +1692,10 @@ RrdGraph.prototype.leg_place = function (calc_width)
 				default_txtalign = this.gdes[i].txtalign;
 
 			if (!this.force_rules_legend) {
+				if ((this.gdes[i].gf === RrdGraphDesc.GF_HRULE || this.gdes[i].gf === RrdGraphDesc.GF_VRULE) &&
+					this.gdes[i].legend === '  ') {
+					this.gdes[i].legend = '';
+				}
 				if (this.gdes[i].gf === RrdGraphDesc.GF_HRULE && (this.gdes[i].yrule < this.minval || this.gdes[i].yrule > this.maxval))
 					this.gdes[i].legend = null;
 				if (this.gdes[i].gf === RrdGraphDesc.GF_VRULE && (this.gdes[i].xrule < this.start || this.gdes[i].xrule > this.end))


### PR DESCRIPTION
HRULEs with empty description text don't create legend entries in rrdgraph, but they do in jsrrdgraph. This pull request will fix it.

Example HRULE:

```
HRULE:4#ecd748::dashes
```

rrdgraph example with such an HRULE:

![rrdgraph_1](https://cloud.githubusercontent.com/assets/2831985/6540192/2c1791ae-c445-11e4-9878-9bfcd3c6f638.png)

Current behavior of jsrrdgraph:

![1](https://cloud.githubusercontent.com/assets/2831985/6540199/38e8171e-c445-11e4-953d-6de9f90ee825.png)

Behavior of jsrrdgraph with the attached change:

![2](https://cloud.githubusercontent.com/assets/2831985/6540201/409531c2-c445-11e4-9240-a4f0a3fa9e26.png)
